### PR TITLE
Adjust composer configuration for TYPO3 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,15 @@
   "type": "typo3-cms-extension",
   "keywords": ["TYPO3 CMS", "Pagination"],
   "homepage": "https://github.com/jainishsenjaliya/js_paginate",
-  "version": "3.0.3",
   "support": {
     "issues": "https://github.com/jainishsenjaliya/js_paginate/issues"
   },
   "require": {
-      "typo3/cms": "6.0.0 - 8.9.99"
+      "typo3/cms": "6.0.0 - 8.7.99"
+  },
+  "autoload": {
+    "psr-4": {
+      "JS\\JsPaginate\\": "Classes/"
+    }
   }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '3.0.3',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.0.0 - 8.9.99',
+			'typo3' => '6.0.0 - 8.7.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
With this adjustments, js_paginate can be installed on TYPO3 8 LTS with composer.

Changes:

- Autoloading information added
- Fixed version number removed (use tags instead)